### PR TITLE
Fix Command to Find IP Address

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get update -qq && \
     apt-get clean -yqq
 
 # # Ensure UTF-8 lang and locale
+RUN sed -Ei 's/^#[[:space:]]*(en_US.UTF-8[[:space:]].*)$/\1/' /etc/locale.gen
 RUN locale-gen en_US.UTF-8
 ENV LANG       en_US.UTF-8
 ENV LC_ALL     en_US.UTF-8

--- a/docker-data/docker-entrypoint.sh
+++ b/docker-data/docker-entrypoint.sh
@@ -35,7 +35,9 @@ if [ "$1" = 'redis-cluster' ]; then
       # inet addr:172.18.0.20  Bcast:172.18.255.255  Mask:255.255.0.0
       # Debian 9
       # inet 172.18.0.4  netmask 255.255.0.0  broadcast 0.0.0.0
-      IP=`ifconfig | grep "inet .*172" | sed -e "s/^[^1]*//" -e "s/ .*//"`
+      IP=`ifconfig | awk '/inet (addr:)?/ && !/inet (addr:)?127/ {
+        sub(/addr:/, "", $2); print $2; exit;
+      }'`
     fi
     echo "yes" | ruby /redis/src/redis-trib.rb create --replicas 1 ${IP}:7000 ${IP}:7001 ${IP}:7002 ${IP}:7003 ${IP}:7004 ${IP}:7005
     tail -f /var/log/supervisor/redis*.log

--- a/docker-data/generate-supervisor-conf.sh
+++ b/docker-data/generate-supervisor-conf.sh
@@ -15,6 +15,14 @@ autorestart=true
 }
 
 result_str="
+[inet_http_server]
+port=127.0.0.1:9001
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[supervisorctl]
+
 [supervisord]
 nodaemon=false
 "


### PR DESCRIPTION
The current command to detect the IP address for cluster nodes seems to have a hard-coded assumption that the container will have an IP address that starts with 172. This assumption doesn't seem to always be correct. For example, on my host docker-compose creates a 192.168/16 network for containers. This change updates the command for IP address detection to find the first non-loopback IP address.

It also has a change to enable supervisorctl for supervisord. This is useful, e.g., for stopping nodes for fault tolerance testing.

Finally, there is a minor change to un-comment en_US.UTF-8 from /etc/locale.gen. Without this change, locale-gen doesn't actually build the locale, and may result in annoying errors about bash or other programs not being able to set the locale.